### PR TITLE
Feat/哲学者の食事回数を管理する機能

### DIFF
--- a/philo/Makefile
+++ b/philo/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/08 01:21:55 by miyuu             #+#    #+#              #
-#    Updated: 2025/04/20 14:17:38 by miyuu            ###   ########.fr        #
+#    Updated: 2025/04/20 19:42:01 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -27,7 +27,8 @@ SRC_FILES = main.c \
 			mulch_thread.c \
 			init_die_judge.c \
 			get_now_time_ms.c \
-			setup_thread_resources.c
+			setup_thread_resources.c \
+			judgement_stop_thread.c
 
 # Header files
 HEADER = $(HEADER_DIR)/philo.h

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:53:30 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:02:26 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:46:02 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ typedef struct s_thread_arg
 typedef struct s_die_judge
 {
 	pthread_t		thread_id;
+	long			start_tv_ms;
 	long			*last_eat_time;
 	bool			*is_philo_die;
 	bool			*is_eat_full;
@@ -81,7 +82,7 @@ int				setup_thread_resources(t_univ_rules rules, \
 void			init_thread_arg(t_univ_rules rules, t_share_data *s_data, \
 								long start_tv_ms);
 void			init_die_judge(t_die_judge	*die_judge, t_univ_rules rules, \
-								t_share_data *s_data);
+								t_share_data *s_data, long start_tv_ms);
 void			mulch_thread(t_univ_rules rules);
 void			*action_philosophers(void *arg);
 void			*judgement_philo_dead(void *arg);

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:53:30 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:46:02 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:41:56 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ typedef struct s_thread_arg
 	int				second_fork_n;
 	long			start_tv_ms;
 	long			*last_eat_time;
-	bool			*is_philo_die;
+	bool			*can_stop_thread;
 	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_thread_arg;
@@ -57,7 +57,7 @@ typedef struct s_die_judge
 	pthread_t		thread_id;
 	long			start_tv_ms;
 	long			*last_eat_time;
-	bool			*is_philo_die;
+	bool			*can_stop_thread;
 	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_die_judge;
@@ -67,7 +67,7 @@ typedef struct s_share_data
 	t_thread_arg	*arg;
 	pthread_mutex_t	*forks;
 	long			*last_eat_time;
-	bool			*is_philo_die;
+	bool			*can_stop_thread;
 	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_share_data;
@@ -85,7 +85,8 @@ void			init_die_judge(t_die_judge	*die_judge, t_univ_rules rules, \
 								t_share_data *s_data, long start_tv_ms);
 void			mulch_thread(t_univ_rules rules);
 void			*action_philosophers(void *arg);
-void			*judgement_philo_dead(void *arg);
+void			*judgement_stop_thread(void *arg);
 long			get_now_time_ms(void);
+void			*judgement_stop_thread(void *arg);
 
 #endif

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:53:30 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 14:17:38 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:02:26 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,7 @@ typedef struct s_thread_arg
 	long			start_tv_ms;
 	long			*last_eat_time;
 	bool			*is_philo_die;
+	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_thread_arg;
 
@@ -56,6 +57,7 @@ typedef struct s_die_judge
 	pthread_t		thread_id;
 	long			*last_eat_time;
 	bool			*is_philo_die;
+	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_die_judge;
 
@@ -65,6 +67,7 @@ typedef struct s_share_data
 	pthread_mutex_t	*forks;
 	long			*last_eat_time;
 	bool			*is_philo_die;
+	bool			*is_eat_full;
 	t_univ_rules	u_rules;
 }	t_share_data;
 

--- a/philo/src/init_die_judge.c
+++ b/philo/src/init_die_judge.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 19:35:53 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 14:03:25 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:16:20 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,11 @@ void	print_one_die_judge(t_die_judge *judge)
 	printf("is_philo_die    : %s (addr: %p)\n",
 		*(judge->is_philo_die) ? "true" : "false",
 		(void *)judge->is_philo_die);
+	printf("is_eat_full   :\n");
+	for (int i = 0; i < judge->u_rules.total_philo; i++)
+	{
+		printf("  [%d] %s (addr: %p)\n", i, judge->is_eat_full[i] ? "true" : "false", (void *)&judge->is_eat_full[i]);
+	}
 	printf("----------------------\n");
 }
 
@@ -32,5 +37,6 @@ void	init_die_judge(t_die_judge	*die_judge, t_univ_rules rules, \
 	die_judge->u_rules = rules;
 	die_judge->last_eat_time = s_data->last_eat_time;
 	die_judge->is_philo_die = s_data->is_philo_die;
+	die_judge->is_eat_full = s_data->is_eat_full;
 	print_one_die_judge(die_judge);
 }

--- a/philo/src/init_die_judge.c
+++ b/philo/src/init_die_judge.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 19:35:53 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:55:58 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:39:32 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,9 +21,9 @@ void	print_one_die_judge(t_die_judge *judge)
 	{
 		printf("  [%d] %ld (addr: %p)\n", i, judge->last_eat_time[i], (void *)&judge->last_eat_time[i]);
 	}
-	printf("is_philo_die    : %s (addr: %p)\n",
-		*(judge->is_philo_die) ? "true" : "false",
-		(void *)judge->is_philo_die);
+	printf("can_stop_thread    : %s (addr: %p)\n",
+		*(judge->can_stop_thread) ? "true" : "false",
+		(void *)judge->can_stop_thread);
 	printf("is_eat_full   :\n");
 	for (int i = 0; i < judge->u_rules.total_philo; i++)
 	{
@@ -38,7 +38,7 @@ void	init_die_judge(t_die_judge	*die_judge, t_univ_rules rules, \
 	die_judge->start_tv_ms = start_tv_ms;
 	die_judge->u_rules = rules;
 	die_judge->last_eat_time = s_data->last_eat_time;
-	die_judge->is_philo_die = s_data->is_philo_die;
+	die_judge->can_stop_thread = s_data->can_stop_thread;
 	die_judge->is_eat_full = s_data->is_eat_full;
 	print_one_die_judge(die_judge);
 }

--- a/philo/src/init_die_judge.c
+++ b/philo/src/init_die_judge.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/19 19:35:53 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:16:20 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:55:58 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 void	print_one_die_judge(t_die_judge *judge)
 {
 	printf("--- die_judge 情報 ---\n");
+	printf("start_tv_ms   : %ld\n", judge->start_tv_ms);
 	printf("last_eat_time   :\n");
 	for (int i = 0; i < judge->u_rules.total_philo; i++)
 	{
@@ -32,8 +33,9 @@ void	print_one_die_judge(t_die_judge *judge)
 }
 
 void	init_die_judge(t_die_judge	*die_judge, t_univ_rules rules, \
-						t_share_data *s_data)
+						t_share_data *s_data, long start_tv_ms)
 {
+	die_judge->start_tv_ms = start_tv_ms;
 	die_judge->u_rules = rules;
 	die_judge->last_eat_time = s_data->last_eat_time;
 	die_judge->is_philo_die = s_data->is_philo_die;

--- a/philo/src/init_thread_arg.c
+++ b/philo/src/init_thread_arg.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 20:32:11 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:19:51 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:39:32 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ void	print_one_thread_arg(t_thread_arg *arg)
 	printf("second_fork_n  : %d\n", arg->second_fork_n);
 	printf("start_tv_ms   : %ld\n", arg->start_tv_ms);
 	printf("last_eat_time : %ld (%p)\n", *(arg->last_eat_time), (void *)arg->last_eat_time);
-	printf("is_philo_die  : %s (%p)\n", *(arg->is_philo_die) ? "true" : "false", (void *)arg->is_philo_die);
+	printf("can_stop_thread  : %s (%p)\n", *(arg->can_stop_thread) ? "true" : "false", (void *)arg->can_stop_thread);
 	printf("is_eat_full : %s (%p)\n", *(arg->is_eat_full) ? "true" : "false", (void *)arg->is_eat_full);
 	printf("----------------------\n");
 }
@@ -61,7 +61,7 @@ void	init_thread_arg(t_univ_rules rules, t_share_data *s_data, \
 		arg[i].u_rules = rules;
 		arg[i].start_tv_ms = start_tv_ms;
 		arg[i].last_eat_time = &s_data->last_eat_time[i];
-		arg[i].is_philo_die = s_data->is_philo_die;
+		arg[i].can_stop_thread = s_data->can_stop_thread;
 		arg[i].is_eat_full = &s_data->is_eat_full[i];
 		assign_forks(&arg[i], s_data->forks, rules.total_philo, i);
 		print_one_thread_arg(&arg[i]);

--- a/philo/src/init_thread_arg.c
+++ b/philo/src/init_thread_arg.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 20:32:11 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 12:36:48 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:19:51 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ void	print_one_thread_arg(t_thread_arg *arg)
 	printf("start_tv_ms   : %ld\n", arg->start_tv_ms);
 	printf("last_eat_time : %ld (%p)\n", *(arg->last_eat_time), (void *)arg->last_eat_time);
 	printf("is_philo_die  : %s (%p)\n", *(arg->is_philo_die) ? "true" : "false", (void *)arg->is_philo_die);
+	printf("is_eat_full : %s (%p)\n", *(arg->is_eat_full) ? "true" : "false", (void *)arg->is_eat_full);
 	printf("----------------------\n");
 }
 
@@ -61,6 +62,7 @@ void	init_thread_arg(t_univ_rules rules, t_share_data *s_data, \
 		arg[i].start_tv_ms = start_tv_ms;
 		arg[i].last_eat_time = &s_data->last_eat_time[i];
 		arg[i].is_philo_die = s_data->is_philo_die;
+		arg[i].is_eat_full = &s_data->is_eat_full[i];
 		assign_forks(&arg[i], s_data->forks, rules.total_philo, i);
 		print_one_thread_arg(&arg[i]);
 		i++;

--- a/philo/src/judgement_stop_thread.c
+++ b/philo/src/judgement_stop_thread.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   judgement_stop_thread.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/20 19:41:33 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/20 19:41:45 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <philo.h>
+
+bool	did_someone_die(int philo_id, t_die_judge *data)
+{
+	long	now_ms;
+	int		time_die;
+
+	time_die = data->u_rules.time_die;
+	if (data->last_eat_time[philo_id] != -1)
+	{
+		now_ms = get_now_time_ms();
+		if (now_ms - data->last_eat_time[philo_id] >= time_die)
+		{
+			printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, スタートから %ldms, die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->start_tv_ms, time_die);
+			printf_philo_status("died", data->start_tv_ms, philo_id + 1, data->last_eat_time[philo_id]);
+			return (true);
+		}
+	}
+	return (false);
+}
+
+void	*judgement_stop_thread(void *arg)
+{
+	t_die_judge		*data;
+	int				total_philo;
+	bool			stop_thread;
+	int				i;
+
+	data = (t_die_judge *)arg;
+	total_philo = data->u_rules.total_philo;
+	while (!*data->can_stop_thread)
+	{
+		i = 0;
+		stop_thread = true;
+		while (i < total_philo)
+		{
+			if (did_someone_die(i, data))
+			{
+				stop_thread = true;
+				break ;
+			}
+			if (!data->is_eat_full[i])
+				stop_thread = false;
+			i++;
+		}
+		if (stop_thread)
+		{
+			printf("\x1b[31m --stop_thread --  \x1b[39m\n");
+			*data->can_stop_thread = true;
+			return (NULL);
+		}
+	}
+	return (NULL);
+}

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 19:13:43 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:31:58 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -99,9 +99,11 @@ void	*action_philosophers(void *arg)
 	t_thread_arg	*data;
 	t_univ_rules	rules;
 	long			last_tv_ms;
+	int				eat_num;
 
 	data = (t_thread_arg *)arg;
 	rules = data->u_rules;
+	eat_num = 0;
 	while (!*data->is_philo_die)
 	{
 		take_forks(data);
@@ -120,6 +122,9 @@ void	*action_philosophers(void *arg)
 			put_forks(data);
 			break ;
 		}
+		if (++eat_num >= rules.must_eat && rules.must_eat != -1)
+			*data->is_eat_full = true;
+		printf("%d : eat_num = %d\n", data->philo_id + 1, eat_num);
 		put_forks(data);
 
 		if (*data->is_philo_die)

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,38 +6,48 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 16:00:08 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:37:41 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/philo.h"
 
+bool	did_someone_die(int philo_id, t_die_judge *data)
+{
+	long	now_ms;
+	int		time_die;
+
+	time_die = data->u_rules.time_die;
+	if (data->last_eat_time[philo_id] != -1)
+	{
+		now_ms = get_now_time_ms();
+		if (now_ms - data->last_eat_time[philo_id] >= time_die)
+		{
+			printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, 差分 %ld die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->last_eat_time[philo_id], time_die);
+			printf_philo_status("died", now_ms, philo_id + 1, 0);
+			return (true);
+		}
+	}
+	return (false);
+}
+
 void	*judgement_philo_dead(void *arg)
 {
 	t_die_judge		*data;
-	int				time_die;
 	int				total_philo;
 	int				i;
-	long			now_ms;
 
 	data = (t_die_judge *)arg;
-	time_die = data->u_rules.time_die;
 	total_philo = data->u_rules.total_philo;
 	while (!*data->is_philo_die)
 	{
 		i = 0;
 		while (i < total_philo)
 		{
-			if (data->last_eat_time[i] != -1)
+			if (did_someone_die(i, data))
 			{
-				now_ms = get_now_time_ms();
-				if (now_ms - data->last_eat_time[i] >= time_die)
-				{
-					*data->is_philo_die = true;
-					printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, 差分 %ld die %d\n", i + 1, now_ms,  data->last_eat_time[i], now_ms - data->last_eat_time[i], time_die);
-					printf_philo_status("died", now_ms, i + 1, 0);
-					break ;
-				}
+				*data->is_philo_die = true;
+				return (NULL);
 			}
 			i++;
 		}

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:55:52 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:13:43 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@ void	*judgement_philo_dead(void *arg)
 {
 	t_die_judge		*data;
 	int				total_philo;
+	bool			stop_thread;
 	int				i;
 
 	data = (t_die_judge *)arg;
@@ -42,14 +43,23 @@ void	*judgement_philo_dead(void *arg)
 	while (!*data->is_philo_die)
 	{
 		i = 0;
+		stop_thread = true;
 		while (i < total_philo)
 		{
 			if (did_someone_die(i, data))
 			{
-				*data->is_philo_die = true;
-				return (NULL);
+				stop_thread = true;
+				break ;
 			}
+			if (!data->is_eat_full[i])
+				stop_thread = false;
 			i++;
+		}
+		if (stop_thread)
+		{
+			printf("\x1b[31m --stop_thread --  \x1b[39m\n");
+			*data->is_philo_die = true;
+			return (NULL);
 		}
 	}
 	return (NULL);

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:37:41 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:55:52 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,8 @@ bool	did_someone_die(int philo_id, t_die_judge *data)
 		now_ms = get_now_time_ms();
 		if (now_ms - data->last_eat_time[philo_id] >= time_die)
 		{
-			printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, 差分 %ld die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->last_eat_time[philo_id], time_die);
-			printf_philo_status("died", now_ms, philo_id + 1, 0);
+			printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, スタートから %ldms, die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->start_tv_ms, time_die);
+			printf_philo_status("died", data->start_tv_ms, philo_id + 1, data->last_eat_time[philo_id]);
 			return (true);
 		}
 	}
@@ -88,7 +88,6 @@ void	*action_philosophers(void *arg)
 {
 	t_thread_arg	*data;
 	t_univ_rules	rules;
-	struct timeval	tv;
 	long			last_tv_ms;
 
 	data = (t_thread_arg *)arg;
@@ -96,8 +95,7 @@ void	*action_philosophers(void *arg)
 	while (!*data->is_philo_die)
 	{
 		take_forks(data);
-		gettimeofday(&tv, NULL);
-		last_tv_ms = tv.tv_sec * UNIT_CONV + tv.tv_usec / UNIT_CONV;
+		last_tv_ms = get_now_time_ms();
 		if (*data->is_philo_die)
 		{
 			put_forks(data);
@@ -141,14 +139,13 @@ int	main(int argc, char *argv[])
 		return (1);
 	}
 	rules = init_univ_rules(argc, argv);
-
+	printf("-----------------\n");
 	printf("Philosophers: %d\n", rules.total_philo);
 	printf("Time to die: %d\n", rules.time_die);
 	printf("Time to eat: %d\n", rules.time_eat);
 	printf("Time to sleep: %d\n", rules.time_sleep);
 	printf("Each must eat: %d\n", rules.must_eat);
-
+	printf("-----------------\n");
 	mulch_thread(rules);
-
 	return (0);
 }

--- a/philo/src/mulch_thread.c
+++ b/philo/src/mulch_thread.c
@@ -83,6 +83,7 @@ void	cleanup_resources(int total_philo, t_share_data *s_data)
 	free(s_data->arg);
 	free(s_data->last_eat_time);
 	free(s_data->is_philo_die);
+	free(s_data->is_eat_full);
 }
 
 void	mulch_thread(t_univ_rules rules)

--- a/philo/src/mulch_thread.c
+++ b/philo/src/mulch_thread.c
@@ -19,7 +19,7 @@ int	create_philosopher_threads(t_univ_rules *rules, t_share_data *s_data, \
 	int			s;
 
 	s = pthread_create(&die_judge->thread_id, NULL, \
-		judgement_philo_dead, die_judge);
+		judgement_stop_thread, die_judge);
 	if (s != 0)
 	{
 		printf("pthread_create: %s\n", strerror(s));
@@ -82,7 +82,7 @@ void	cleanup_resources(int total_philo, t_share_data *s_data)
 	free(s_data->forks);
 	free(s_data->arg);
 	free(s_data->last_eat_time);
-	free(s_data->is_philo_die);
+	free(s_data->can_stop_thread);
 	free(s_data->is_eat_full);
 }
 

--- a/philo/src/printf_philo_status.c
+++ b/philo/src/printf_philo_status.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 19:28:46 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 16:02:28 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:51:42 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,9 @@
 long	printf_philo_status(char *status, long s_time, \
 							int n_philo, long last_time)
 {
-	struct timeval	tv;
 	long			now_ms;
 
-	gettimeofday(&tv, NULL);
-	now_ms = tv.tv_sec * UNIT_CONV + tv.tv_usec / UNIT_CONV;
+	now_ms = get_now_time_ms();
 	printf(LOG_STATUS, now_ms - s_time, n_philo, status, now_ms - last_time);
 	return (now_ms);
 }

--- a/philo/src/setup_thread_resources.c
+++ b/philo/src/setup_thread_resources.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 14:10:33 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:06:40 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:46:22 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,6 @@ int	setup_thread_resources(t_univ_rules rules, t_share_data	*s_data, \
 	}
 	start_tv_ms = get_now_time_ms();
 	init_thread_arg(rules, s_data, start_tv_ms);
-	init_die_judge(die_judge, rules, s_data);
+	init_die_judge(die_judge, rules, s_data, start_tv_ms);
 	return (0);
 }

--- a/philo/src/setup_thread_resources.c
+++ b/philo/src/setup_thread_resources.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 14:10:33 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 18:46:22 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:04:07 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,21 +44,11 @@ int	setup_thread_resources(t_univ_rules rules, t_share_data	*s_data, \
 	while (rules.total_philo > i)
 	{
 		pthread_mutex_init(&s_data->forks[i], NULL);
-		i++;
-	}
-	i = 0;
-	while (rules.total_philo > i)
-	{
 		s_data->last_eat_time[i] = -1;
+		s_data->is_eat_full[i] = false;
 		i++;
 	}
 	*s_data->is_philo_die = false;
-	i = 0;
-	while (rules.total_philo > i)
-	{
-		s_data->is_philo_die[i] = false;
-		i++;
-	}
 	start_tv_ms = get_now_time_ms();
 	init_thread_arg(rules, s_data, start_tv_ms);
 	init_die_judge(die_judge, rules, s_data, start_tv_ms);

--- a/philo/src/setup_thread_resources.c
+++ b/philo/src/setup_thread_resources.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 14:10:33 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 19:04:07 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 19:39:32 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,11 +23,11 @@ static int	allocate_memory(int total_philo, t_share_data *s_data)
 	s_data->last_eat_time = malloc(total_philo * sizeof(long));
 	if (s_data->last_eat_time == NULL)
 		return (-1);
-	s_data->is_philo_die = malloc(sizeof(bool));
-	if (s_data->is_philo_die == NULL)
+	s_data->can_stop_thread = malloc(sizeof(bool));
+	if (s_data->can_stop_thread == NULL)
 		return (-1);
 	s_data->is_eat_full = malloc(total_philo * sizeof(bool));
-	if (s_data->is_philo_die == NULL)
+	if (s_data->can_stop_thread == NULL)
 		return (-1);
 	return (0);
 }
@@ -48,7 +48,7 @@ int	setup_thread_resources(t_univ_rules rules, t_share_data	*s_data, \
 		s_data->is_eat_full[i] = false;
 		i++;
 	}
-	*s_data->is_philo_die = false;
+	*s_data->can_stop_thread = false;
 	start_tv_ms = get_now_time_ms();
 	init_thread_arg(rules, s_data, start_tv_ms);
 	init_die_judge(die_judge, rules, s_data, start_tv_ms);

--- a/philo/src/setup_thread_resources.c
+++ b/philo/src/setup_thread_resources.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 14:10:33 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 14:16:35 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/20 18:06:40 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,9 @@ static int	allocate_memory(int total_philo, t_share_data *s_data)
 	s_data->is_philo_die = malloc(sizeof(bool));
 	if (s_data->is_philo_die == NULL)
 		return (-1);
-	*s_data->is_philo_die = false;
+	s_data->is_eat_full = malloc(total_philo * sizeof(bool));
+	if (s_data->is_philo_die == NULL)
+		return (-1);
 	return (0);
 }
 
@@ -51,6 +53,12 @@ int	setup_thread_resources(t_univ_rules rules, t_share_data	*s_data, \
 		i++;
 	}
 	*s_data->is_philo_die = false;
+	i = 0;
+	while (rules.total_philo > i)
+	{
+		s_data->is_philo_die[i] = false;
+		i++;
+	}
 	start_tv_ms = get_now_time_ms();
 	init_thread_arg(rules, s_data, start_tv_ms);
 	init_die_judge(die_judge, rules, s_data);


### PR DESCRIPTION
## 変更点
5つ目の引数である`number_of_times_each_philosopher_must_eat`の機能を追加

## 追加関数など <!-- 具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
### 追加ファイル
- judgement_stop_thread.c
### 追加関数
- did_someone_die関数
→judgement_stop_thread関数から分けた

### 変更構造値
- 各構造体に、哲学者が満腹かを表す`bool *is_eat_full`を追加
- `is_philo_die`変数を、`can_stop_thread`に命名変更

## norminette <!-- norminetteエラーがあるファイルを記載してください。 -->

```bash
norminette | grep Error!
src/init_die_judge.c: Error!
src/judgement_stop_thread.c: Error!
src/main.c: Error!
src/init_thread_arg.c: Error!
```

## 問題点
めっちゃ哲学者死ぬ
→2回連続で食事をしないように、強制thinkingタイムを設けたい

### 確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [ ] セグフォ・リーク・free忘れはありませんか？
+ [ ] 可能なかぎりnorminette対応しましたか？
