### PR TITLE
feat/usleepでのラグを改善した

### DIFF
--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:53:30 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 15:23:03 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:33:22 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,8 @@ typedef struct s_univ_rules
 {
 	int	total_philo;
 	int	time_die_ms;
-	int	time_eat_us;
-	int	time_sleep_us;
+	int	time_eat_ms;
+	int	time_sleep_ms;
 	int	must_eat;
 }	t_univ_rules;
 

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:53:30 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 11:31:55 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:23:03 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,16 +24,16 @@
 
 /* macro */
 # define UNIT_CONV 1000
-# define DEBUG_LOG_STATUS "\x1b[32m%ld\x1b[39m %d %s, diff: \x1b[32m%ld\x1b[39m\n"
+// # define DEBUG_LOG_STATUS "\x1b[32m%ld\x1b[39m %d %s, diff: \x1b[32m%ld\x1b[39m\n"
 # define LOG_STATUS "\x1b[32m%ld\x1b[39m %d %s\n"
 
 /* struct */
 typedef struct s_univ_rules
 {
 	int	total_philo;
-	int	time_die;
-	int	time_eat;
-	int	time_sleep;
+	int	time_die_ms;
+	int	time_eat_us;
+	int	time_sleep_us;
 	int	must_eat;
 }	t_univ_rules;
 

--- a/philo/src/get_now_time_ms.c
+++ b/philo/src/get_now_time_ms.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 12:14:00 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 12:14:19 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:17:33 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,9 +15,9 @@
 long	get_now_time_ms(void)
 {
 	struct timeval	tv;
-	long			now_tv_ms;
+	long			now_ms;
 
 	gettimeofday(&tv, NULL);
-	now_tv_ms = tv.tv_sec * UNIT_CONV + tv.tv_usec / UNIT_CONV;
-	return (now_tv_ms);
+	now_ms = tv.tv_sec * UNIT_CONV + tv.tv_usec / UNIT_CONV;
+	return (now_ms);
 }

--- a/philo/src/init_univ_rules.c
+++ b/philo/src/init_univ_rules.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 18:27:06 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/20 23:14:14 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:20:39 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,9 @@
 // {
 // 	printf("--- rules 情報 ---\n");
 // 	printf("Philosophers: %d\n", rules.total_philo);
-// 	printf("Time to die: %d\n", rules.time_die);
-// 	printf("Time to eat: %d\n", rules.time_eat);
-// 	printf("Time to sleep: %d\n", rules.time_sleep);
+// 	printf("Time to die: %d\n", rules.time_die_ms);
+// 	printf("Time to eat: %d\n", rules.time_eat_us);
+// 	printf("Time to sleep: %d\n", rules.time_sleep_us);
 // 	printf("Each must eat: %d\n", rules.must_eat);
 // 	printf("-----------------\n");
 // }
@@ -28,9 +28,9 @@ t_univ_rules	init_univ_rules(int argc, char *argv[])
 	t_univ_rules	rules;
 
 	rules.total_philo = atoi(argv[1]);
-	rules.time_die = atoi(argv[2]);
-	rules.time_eat = atoi(argv[3]);
-	rules.time_sleep = atoi(argv[4]);
+	rules.time_die_ms = atoi(argv[2]);
+	rules.time_eat_us = atoi(argv[3]) * UNIT_CONV;
+	rules.time_sleep_us = atoi(argv[4]) * UNIT_CONV;
 	if (argc == 6)
 		rules.must_eat = atoi(argv[5]);
 	else

--- a/philo/src/init_univ_rules.c
+++ b/philo/src/init_univ_rules.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/15 18:27:06 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 15:20:39 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:32:45 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,8 @@
 // 	printf("--- rules 情報 ---\n");
 // 	printf("Philosophers: %d\n", rules.total_philo);
 // 	printf("Time to die: %d\n", rules.time_die_ms);
-// 	printf("Time to eat: %d\n", rules.time_eat_us);
-// 	printf("Time to sleep: %d\n", rules.time_sleep_us);
+// 	printf("Time to eat: %d\n", rules.time_eat_ms);
+// 	printf("Time to sleep: %d\n", rules.time_sleep_ms);
 // 	printf("Each must eat: %d\n", rules.must_eat);
 // 	printf("-----------------\n");
 // }
@@ -29,8 +29,8 @@ t_univ_rules	init_univ_rules(int argc, char *argv[])
 
 	rules.total_philo = atoi(argv[1]);
 	rules.time_die_ms = atoi(argv[2]);
-	rules.time_eat_us = atoi(argv[3]) * UNIT_CONV;
-	rules.time_sleep_us = atoi(argv[4]) * UNIT_CONV;
+	rules.time_eat_ms = atoi(argv[3]);
+	rules.time_sleep_ms = atoi(argv[4]);
 	if (argc == 6)
 		rules.must_eat = atoi(argv[5]);
 	else

--- a/philo/src/judgement_stop_thread.c
+++ b/philo/src/judgement_stop_thread.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/20 19:41:33 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 11:57:37 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:19:35 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,15 +15,15 @@
 bool	did_someone_die(int philo_id, t_die_judge *data)
 {
 	long	now_ms;
-	int		time_die;
+	int		time_die_ms;
 
-	time_die = data->u_rules.time_die;
+	time_die_ms = data->u_rules.time_die_ms;
 	if (data->last_eat_time[philo_id] != -1)
 	{
 		now_ms = get_now_time_ms();
-		if (now_ms - data->last_eat_time[philo_id] >= time_die)
+		if (now_ms - data->last_eat_time[philo_id] >= time_die_ms)
 		{
-			// printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, スタートから %ldms, die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->start_tv_ms, time_die);
+			// printf("ジャッジ関数%d : 今: %ld , 最後の食事 %ld, スタートから %ldms, die %d\n", philo_id + 1, now_ms, data->last_eat_time[philo_id], now_ms - data->start_tv_ms, time_die_ms);
 			printf_philo_status("died", *data->start_tv_ms, philo_id + 1, data->last_eat_time[philo_id]);
 			return (true);
 		}

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 15:59:26 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 16:04:08 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,11 +83,7 @@ void	*action_philosophers(void *arg)
 		now_ms = printf_philo_status("is eating", *data->start_tv_ms, data->philo_id + 1, now_ms);
 		*data->last_eat_time = now_ms;
 		while (get_now_time_ms() - now_ms < rules.time_eat_ms)
-		{
 			usleep(rules.time_eat_ms);
-			// printf("eat_ms %d, diff: %ld\n", rules.time_eat_ms, get_now_time_ms() - now_ms);
-		}
-		// usleep(rules.time_eat_ms);
 		put_forks(data);
 
 		if (*data->can_stop_thread)
@@ -99,12 +95,8 @@ void	*action_philosophers(void *arg)
 			break ;
 		/* eatが終わり、sleepを開始 */
 		now_ms = printf_philo_status("is sleeping", *data->start_tv_ms, data->philo_id + 1, now_ms);
-		// usleep(rules.time_sleep_ms);
 		while (get_now_time_ms() - now_ms < rules.time_sleep_ms)
-		{
 			usleep(rules.time_sleep_ms);
-			// printf("eat_ms %d, diff: %ld\n", rules.time_sleep_ms, get_now_time_ms() - now_ms);
-		}
 
 		if (*data->can_stop_thread)
 			break ;

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 12:29:39 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:22:48 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,18 +43,18 @@ void	take_forks(t_thread_arg *philo)
 
 void	thinking_lag(t_univ_rules rules)
 {
-	long	t_eat_ms;
-	long	t_sleep_ms;
-	long	t_think;
+	long	eat_us;
+	long	sleep_us;
+	long	think_us;
 
 	if (rules.total_philo % 2 == 0)
 		return ;
-	t_eat_ms = rules.time_eat;
-	t_sleep_ms = rules.time_sleep;
-	t_think = t_eat_ms * 2 - t_sleep_ms;
-	if (t_think < 0)
-		t_think = 0;
-	usleep(t_think * 0.3 * UNIT_CONV);
+	eat_us = rules.time_eat_us;
+	sleep_us = rules.time_sleep_us;
+	think_us = eat_us * 2 - sleep_us;
+	if (think_us < 0)
+		think_us = 0;
+	usleep(think_us * 0.3);
 }
 
 void	*action_philosophers(void *arg)
@@ -82,7 +82,8 @@ void	*action_philosophers(void *arg)
 		/* eatを開始 */
 		last_tv_ms = printf_philo_status("is eating", *data->start_tv_ms, data->philo_id + 1, last_tv_ms);
 		*data->last_eat_time = last_tv_ms;
-		usleep(rules.time_eat * UNIT_CONV);
+		// usleep(rules.time_eat_us * UNIT_CONV);
+		usleep(rules.time_eat_us);
 		put_forks(data);
 
 		if (*data->can_stop_thread)
@@ -94,7 +95,7 @@ void	*action_philosophers(void *arg)
 			break ;
 		/* eatが終わり、sleepを開始 */
 		last_tv_ms = printf_philo_status("is sleeping", *data->start_tv_ms, data->philo_id + 1, last_tv_ms);
-		usleep(rules.time_sleep * UNIT_CONV);
+		usleep(rules.time_sleep_us);
 
 		if (*data->can_stop_thread)
 			break ;

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/14 19:57:59 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/21 15:34:57 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/21 15:59:26 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,8 +47,6 @@ void	thinking_lag(t_univ_rules rules)
 	long	sleep_ms;
 	long	think_ms;
 
-	if (rules.total_philo % 2 == 0)
-		return ;
 	eat_ms = rules.time_eat_ms;
 	sleep_ms = rules.time_sleep_ms;
 	think_ms = eat_ms * 2 - sleep_ms;
@@ -70,6 +68,8 @@ void	*action_philosophers(void *arg)
 	while (!*data->can_start_eat)
 		;
 	// printf("開始!%d, time: %ld\n", data->philo_id + 1, get_now_time_ms());
+	if (data->philo_id % 2 == 0)
+		thinking_lag(rules);
 	while (!*data->can_stop_thread)
 	{
 		take_forks(data);
@@ -84,7 +84,7 @@ void	*action_philosophers(void *arg)
 		*data->last_eat_time = now_ms;
 		while (get_now_time_ms() - now_ms < rules.time_eat_ms)
 		{
-			usleep(rules.time_eat_ms * 10);
+			usleep(rules.time_eat_ms);
 			// printf("eat_ms %d, diff: %ld\n", rules.time_eat_ms, get_now_time_ms() - now_ms);
 		}
 		// usleep(rules.time_eat_ms);
@@ -102,7 +102,7 @@ void	*action_philosophers(void *arg)
 		// usleep(rules.time_sleep_ms);
 		while (get_now_time_ms() - now_ms < rules.time_sleep_ms)
 		{
-			usleep(rules.time_sleep_ms * 10);
+			usleep(rules.time_sleep_ms);
 			// printf("eat_ms %d, diff: %ld\n", rules.time_sleep_ms, get_now_time_ms() - now_ms);
 		}
 
@@ -113,7 +113,8 @@ void	*action_philosophers(void *arg)
 
 		if (*data->can_stop_thread)
 			break ;
-		thinking_lag(rules);
+		if (rules.total_philo % 2 != 0)
+			thinking_lag(rules);
 	}
 	return (NULL);
 }


### PR DESCRIPTION
## 変更点/追加関数など <!-- 具体的な変更点や修正箇所をリストアップしてください。 -->
- usleep使用時にマルチスレッドにおけるCPU処理から発生するラグがあり、これが改善するようにした
- ついでに、変数名で、ミリ秒(ms)かマイクロ秒(us)かわかるようにした

## テスト <!-- このPRに関連するテストケースやテスト方法を記載してください。 -->
- テストケース
```bash
cd philo/LazyPhilosophersTester/
./test.sh ../philo

 [2] no-die tests (can take a while)はクリア
```
## 未対応/今後のToDo <!-- 未対応/今後やる必要があることを記載してください。 -->
- 使用禁止関数を消す
→atoi→INT_MAXや負の値がきたときの処理を考える
- 哲学者が1だった時の処理を考える
- printfするまえにmutexで保護する
→哲学者が死んだ後に、他の哲学者のtime stampを出力するのを防ぐため
## norminette <!-- norminetteエラーがあるファイルを記載してください。 -->

```bash
norminette | grep Error!
playground/main_pthread.c: Error!
playground/main_filo.c: Error!
playground/main_man.c: Error!
playground/main_thread_conflict.c: Error!
playground/main_mutex.c: Error!
philo/include/philo.h: Error!
philo/src/init_univ_rules.c: Error!
philo/src/init_die_judge.c: Error!
philo/src/judgement_stop_thread.c: Error!
philo/src/main.c: Error!
philo/src/printf_philo_status.c: Error!
philo/src/init_thread_arg.c: Error!
```

### 確認事項 <!-- このPRを出す前に、再度確認してください。 -->
+ [x] コンパイルできますか？
+ [x] 余分なファイルのdiffはありませんか？(ヘッダー部分だけのdiffなど)
+ [x] セグフォ・リーク・free忘れはありませんか？
+ [ ] 可能なかぎりnorminette対応しましたか？
